### PR TITLE
Add theme "Yeblu"

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -227,6 +227,12 @@ const themes = {
     text_color: "ffffff",
     bg_color: "20232a",
   },
+  yeblu: {
+    title_color: "ffff00",
+    icon_color: "ffff00",
+    text_color: "ffffff",
+    bg_color: "002046",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
This is a new theme suggestion for github readme stats

**theme appearance:**
![yeblu github readme stats theme](https://user-images.githubusercontent.com/50571688/94900257-5c4f2780-049d-11eb-9145-9eefd86ec261.JPG)

